### PR TITLE
Prototypes and macros

### DIFF
--- a/esos/include/esos_f14ui.h
+++ b/esos/include/esos_f14ui.h
@@ -127,11 +127,11 @@ int16_t esos_uiF14_getRPGVelocity_i16 (void);
                           } while (0)
 #define ESOS_TASK_WAIT_UNTIL_UIF14_SW3_DOUBLE_PRESSED()       // not yet implemented
 
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS()          // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CW()       // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CCW()      // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM()         // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CW()      // not yet implemented
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS()          ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurning() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CW()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningCW() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CCW()      ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningCCW() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM()         ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningMedium() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CW()      ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningMedium() && esos_uiF14_isRPGTurningCW() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CCW()     // not yet implemented
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST()           // not yet implemented
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST_CW()        // not yet implemented

--- a/esos/include/esos_f14ui.h
+++ b/esos/include/esos_f14ui.h
@@ -109,7 +109,7 @@ int16_t esos_uiF14_getRPGVelocity_i16 (void);
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW1_PRESSED();           /
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW1_RELEASED();          /
                           } while (0) 
-#define ESOS_TASK_WAIT_UNTIL_UIF14_SW1_DOUBLE_PRESSED()       // not yet implemented
+#define ESOS_TASK_WAIT_UNTIL_UIF14_SW1_DOUBLE_PRESSED()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW1DoublePressed() )
 
 #define ESOS_TASK_WAIT_UNTIL_UIF14_SW2_PRESSED()              ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW2Pressed() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_SW2_RELEASED()             ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW2Released() )
@@ -117,7 +117,7 @@ int16_t esos_uiF14_getRPGVelocity_i16 (void);
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW2_PRESSED(); /
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW2_RELEASED(); /
                           } while (0)
-#define ESOS_TASK_WAIT_UNTIL_UIF14_SW2_DOUBLE_PRESSED()       // not yet implemented
+#define ESOS_TASK_WAIT_UNTIL_UIF14_SW2_DOUBLE_PRESSED()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW2DoublePressed() )
 
 #define ESOS_TASK_WAIT_UNTIL_UIF14_SW3_PRESSED()              ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW3Pressed() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_SW3_RELEASED()             ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW3Released() )
@@ -125,17 +125,17 @@ int16_t esos_uiF14_getRPGVelocity_i16 (void);
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW3_PRESSED(); /
                             ESOS_TASK_WAIT_UNTIL_UIF14_SW3_RELEASED(); /
                           } while (0)
-#define ESOS_TASK_WAIT_UNTIL_UIF14_SW3_DOUBLE_PRESSED()       // not yet implemented
+#define ESOS_TASK_WAIT_UNTIL_UIF14_SW3_DOUBLE_PRESSED()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isSW3DoublePressed() )
 
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS()          ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurning() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CW()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningCW() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_UNTIL_TURNS_CCW()      ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningCCW() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM()         ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningMedium() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CW()      ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningMedium() && esos_uiF14_isRPGTurningCW() )
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CCW()     // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST()           // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST_CW()        // not yet implemented
-#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST_CCW()       // not yet implemented
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_MEDIUM_CCW()     ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningMedium() && esos_uiF14_isRPGTurningCCW() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST()           ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningFast() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST_CW()        ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningFast() && esos_uiF14_isRPGTurningCW() )
+#define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_TURNS_FAST_CCW()       ESOS_TASK_WAIT_UNTIL( esos_uiF14_isRPGTurningFast() && esos_uiF14_isRPGTurningCCW() )
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_MAKES_REV(y)           // not yet implemented
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_MAKES_CW_REV(y)        // not yet implemented
 #define ESOS_TASK_WAIT_UNTIL_UIF14_RPG_MAKES_CCW_REV(y)       // not yet implemented

--- a/esos/src/esos_f14ui.c
+++ b/esos/src/esos_f14ui.c
@@ -236,7 +236,8 @@ void config_esos_uiF14() {
   CONFIG_SW3();
 
   //Step 3: setup RPG
-
+  CONFIG_RPGA();
+  CONFIG_RPGB();
   //TODO
 
 

--- a/esos/src/esos_f14ui.c
+++ b/esos/src/esos_f14ui.c
@@ -59,6 +59,9 @@ inline BOOL esos_uiF14_isSW3DoublePressed (void) {
 
 // PUBLIC LED FUNCTIONS
 
+//Ryan: I think some of these functions are intended to actually
+//trigger LED changes, so I'm updating the LED register
+
 inline BOOL esos_uiF14_isLED1On (void) {
     return (_st_esos_uiF14Data.b_LED1On==TRUE);
 }
@@ -68,16 +71,19 @@ inline BOOL esos_uiF14_isLED1Off (void) {
 }
 
 inline void esos_uiF14_turnLED1On (void) {
+    LED1 = 1;
     _st_esos_uiF14Data.b_LED1On = TRUE;
     return;
 }
 
 inline void esos_uiF14_turnLED1Off (void) {
+    LED1 = 0;
     _st_esos_uiF14Data.b_LED1On = FALSE;
     return;
 }
 
 inline void esos_uiF14_toggleLED1 (void) {
+    LED1 = !LED1;
     _st_esos_uiF14Data.b_LED1On ^= 1;
     return;
 }
@@ -96,16 +102,19 @@ inline BOOL esos_uiF14_isLED2Off (void) {
 }
 
 inline void esos_uiF14_turnLED2On (void) {
+    LED2 = 1;
     _st_esos_uiF14Data.b_LED2On = TRUE;
     return;
 }
 
 inline void esos_uiF14_turnLED2Off (void) {
+    LED2 = 0;
     _st_esos_uiF14Data.b_LED2On = FALSE;
     return;
 }
 
 inline void esos_uiF14_toggleLED2 (void) {
+    LED2 = !LED2;
     _st_esos_uiF14Data.b_LED2On ^= 1;
     return;
 }
@@ -124,16 +133,20 @@ inline BOOL esos_uiF14_isLED3Off (void) {
 }
 
 inline void esos_uiF14_turnLED3On (void) {
+    //LED3 is low active
+    LED3 = 0;
     _st_esos_uiF14Data.b_LED3On = TRUE;
     return;
 }
 
 inline void esos_uiF14_turnLED3Off (void) {
+    LED3 = 1;
     _st_esos_uiF14Data.b_LED3On = FALSE;
     return;
 }
 
 inline void esos_uiF14_toggleLED3 (void) {
+    LED3 = !LED3;
     _st_esos_uiF14Data.b_LED3On ^= 1;
     return;
 }


### PR DESCRIPTION
This fills in most of the ESOS macros. Only the macros for waiting on a specific number of rotations need to be filled in.